### PR TITLE
Implement AttCache mechanism for attribute preservation

### DIFF
--- a/libmei/addons/att.h
+++ b/libmei/addons/att.h
@@ -8,6 +8,7 @@
 #ifndef __LIBMEI_ATT_H__
 #define __LIBMEI_ATT_H__
 
+#include <map>
 #include <string>
 
 //----------------------------------------------------------------------------
@@ -180,6 +181,37 @@ public:
     std::string PlacementToStr(data_PLACEMENT data) const;
     data_PLACEMENT StrToPlacement(const std::string &value, bool logWarning = true) const;
     ///@}
+
+    /** @name Virtual methods for caching original values */
+    ///@{
+    virtual bool HasCacheValue(const std::string &attr) const { return false; }
+    virtual std::string GetCacheValue(const std::string &attr) const { return ""; }
+    virtual void SetCacheValue(const std::string &attr, const std::string &value) {}
+    ///@}
+};
+
+//----------------------------------------------------------------------------
+// AttCache
+//----------------------------------------------------------------------------
+
+/**
+ * This is a base class for attribute classes that need to cache the original value.
+ */
+class AttCache : public Att {
+protected:
+    AttCache() : Att() {}
+    ~AttCache() = default;
+
+public:
+    bool HasCacheValue(const std::string &attr) const override { return (m_cache.count(attr) != 0); }
+    std::string GetCacheValue(const std::string &attr) const override
+    {
+        return (m_cache.count(attr) != 0) ? m_cache.at(attr) : "";
+    }
+    void SetCacheValue(const std::string &attr, const std::string &value) override { m_cache[attr] = value; }
+
+private:
+    std::map<std::string, std::string> m_cache;
 };
 
 } // namespace vrv

--- a/libmei/datatypes.yml
+++ b/libmei/datatypes.yml
@@ -223,6 +223,12 @@ modules:
         att.articulation:
             artic:
                 type: data_ARTICULATION_List
+        att.height:
+            height:
+                cached: true
+        att.width:
+            width:
+                cached: true
         att.curvature:
             bulge:
                 type: data_BULGE

--- a/libmei/dist/atts_shared.cpp
+++ b/libmei/dist/atts_shared.cpp
@@ -2291,7 +2291,7 @@ bool AttHandIdent::HasHand() const
 // AttHeight
 //----------------------------------------------------------------------------
 
-AttHeight::AttHeight() : Att()
+AttHeight::AttHeight() : AttCache()
 {
     this->ResetHeight();
 }
@@ -2305,6 +2305,7 @@ bool AttHeight::ReadHeight(pugi::xml_node element, bool removeAttr)
 {
     bool hasAttribute = false;
     if (element.attribute("height")) {
+        this->SetCacheValue("height", element.attribute("height").value());
         this->SetHeight(StrToMeasurementunsigned(element.attribute("height").value()));
         if (removeAttr) element.remove_attribute("height");
         hasAttribute = true;
@@ -2315,7 +2316,10 @@ bool AttHeight::ReadHeight(pugi::xml_node element, bool removeAttr)
 bool AttHeight::WriteHeight(pugi::xml_node element)
 {
     bool wroteAttribute = false;
-    if (this->HasHeight()) {
+    if (this->HasCacheValue("height")) {
+        element.append_attribute("height") = this->GetCacheValue("height").c_str();
+        wroteAttribute = true;
+    } else if (this->HasHeight()) {
         element.append_attribute("height") = MeasurementunsignedToStr(this->GetHeight()).c_str();
         wroteAttribute = true;
     }
@@ -7561,7 +7565,7 @@ bool AttWhitespace::HasSpace() const
 // AttWidth
 //----------------------------------------------------------------------------
 
-AttWidth::AttWidth() : Att()
+AttWidth::AttWidth() : AttCache()
 {
     this->ResetWidth();
 }
@@ -7575,6 +7579,7 @@ bool AttWidth::ReadWidth(pugi::xml_node element, bool removeAttr)
 {
     bool hasAttribute = false;
     if (element.attribute("width")) {
+        this->SetCacheValue("width", element.attribute("width").value());
         this->SetWidth(StrToMeasurementunsigned(element.attribute("width").value()));
         if (removeAttr) element.remove_attribute("width");
         hasAttribute = true;
@@ -7585,7 +7590,10 @@ bool AttWidth::ReadWidth(pugi::xml_node element, bool removeAttr)
 bool AttWidth::WriteWidth(pugi::xml_node element)
 {
     bool wroteAttribute = false;
-    if (this->HasWidth()) {
+    if (this->HasCacheValue("width")) {
+        element.append_attribute("width") = this->GetCacheValue("width").c_str();
+        wroteAttribute = true;
+    } else if (this->HasWidth()) {
         element.append_attribute("width") = MeasurementunsignedToStr(this->GetWidth()).c_str();
         wroteAttribute = true;
     }

--- a/libmei/dist/atts_shared.h
+++ b/libmei/dist/atts_shared.h
@@ -2637,7 +2637,7 @@ public:
 // AttHeight
 //----------------------------------------------------------------------------
 
-class AttHeight : public Att {
+class AttHeight : public AttCache {
 protected:
     AttHeight();
     ~AttHeight() = default;
@@ -8319,7 +8319,7 @@ public:
 // AttWidth
 //----------------------------------------------------------------------------
 
-class AttWidth : public Att {
+class AttWidth : public AttCache {
 protected:
     AttWidth();
     ~AttWidth() = default;

--- a/libmei/tools/cpp.py
+++ b/libmei/tools/cpp.py
@@ -64,7 +64,7 @@ ATTCLASS_H = """
 // Att{attGroupNameUpper}
 //----------------------------------------------------------------------------
 
-class Att{attGroupNameUpper} : public Att {{
+class Att{attGroupNameUpper} : public {attBaseClass} {{
 protected:
     Att{attGroupNameUpper}();
     ~Att{attGroupNameUpper}() = default;
@@ -139,7 +139,7 @@ ATTCLASS_CPP = """
 // Att{attGroupNameUpper}
 //----------------------------------------------------------------------------
 
-Att{attGroupNameUpper}::Att{attGroupNameUpper}() : Att()
+Att{attGroupNameUpper}::Att{attGroupNameUpper}() : {attBaseClass}()
 {{
     this->Reset{attGroupNameUpper}();
 }}
@@ -169,12 +169,12 @@ bool Att{attGroupNameUpper}::Write{attGroupNameUpper}(pugi::xml_node element)
 ATTCLASS_MEMBERS_DEFAULT_CPP = """m_{attNameLowerJoined} = {attDefault};"""
 
 ATTCLASS_READ_CPP = """if (element.attribute("{attNameLower}")) {{
-        this->Set{attNameUpper}({converterRead}(element.attribute("{attNameLower}").value()));
+        {cacheRead}this->Set{attNameUpper}({converterRead}(element.attribute("{attNameLower}").value()));
         if (removeAttr) element.remove_attribute("{attNameLower}");
         hasAttribute = true;
     }}"""
 
-ATTCLASS_WRITE_CPP = """if (this->Has{attNameUpper}()) {{
+ATTCLASS_WRITE_CPP = """{cacheWrite}if (this->Has{attNameUpper}()) {{
         element.append_attribute("{attNameLower}") = {converterWrite}(this->Get{attNameUpper}()).c_str();
         wroteAttribute = true;
     }}"""
@@ -629,6 +629,14 @@ def vrv_is_alternate_type(datatype: str) -> bool:
     return datatype in DATATYPES["alternates"]
 
 
+def vrv_is_cached_attribute(module: str, gp: str, att: str) -> bool:
+    """Return True if an attribute is marked as cached in DATATYPES."""
+    att_config = vrv_get_att_config(module, gp, att)
+    if not att_config:
+        return False
+    return att_config.get("cached", False)
+
+
 def vrv_get_att_config_type(module: str, gp: str, att: str) -> Optional[str]:
     """Return the configured attribute type for a module/group/attribute."""
     att_config = vrv_get_att_config(module, gp, att)
@@ -793,6 +801,12 @@ def create_att_classes(cpp_ns: str, schema, outdir: Path):
             writes: list = []
             checkers: list = []
 
+            is_cached_group = False
+            for att in atts:
+                if vrv_is_cached_attribute(module, gp, att):
+                    is_cached_group = True
+                    break
+
             for att in atts:
                 if "|" in att:
                     # we have a namespaced attribute
@@ -806,6 +820,17 @@ def create_att_classes(cpp_ns: str, schema, outdir: Path):
                 doc_str = create_docstr(schema.get_att_desc(att), indent=4)
                 attdefault, converters = vrv_get_att_default(schema.schema, module, gp, att)
 
+                cache_read = ""
+                cache_write = ""
+                if vrv_is_cached_attribute(module, gp, att):
+                    cache_read = f'this->SetCacheValue("{att_lower_name}", element.attribute("{att_lower_name}").value());\n        '
+                    cache_write = (
+                        f'if (this->HasCacheValue("{att_lower_name}")) {{\n'
+                        f'        element.append_attribute("{att_lower_name}") = this->GetCacheValue("{att_lower_name}").c_str();\n'
+                        f'        wroteAttribute = true;\n'
+                        f'    }} else '
+                    )
+
                 substrings = {
                     "attGroupNameUpper": schema.cc(schema.strpatt(gp)),
                     "attNameUpper": schema.cc(schema.strpatt(att)),
@@ -816,6 +841,9 @@ def create_att_classes(cpp_ns: str, schema, outdir: Path):
                     "attDefault": attdefault,
                     "converterRead": converters[0],
                     "converterWrite": converters[1],
+                    "attBaseClass": "AttCache" if is_cached_group else "Att",
+                    "cacheRead": cache_read,
+                    "cacheWrite": cache_write,
                 }
 
                 if len(methods) > 0:
@@ -843,6 +871,7 @@ def create_att_classes(cpp_ns: str, schema, outdir: Path):
 
             clsubstr = {
                 "attGroupNameUpper": schema.cc(schema.strpatt(gp)),
+                "attBaseClass": "AttCache" if is_cached_group else "Att",
                 "methods": "".join(methods),
                 "members": "".join(members),
                 "defaults": "".join(defaults),


### PR DESCRIPTION
This change introduces a generic caching mechanism for MEI attributes in Verovio. Selected attributes (configured in `libmei/datatypes.yml`) now store their original string value upon reading. When writing the attribute back to MEI, the cached value is prioritized if available, ensuring that units or values that Verovio cannot currently process (e.g., "2000px", "3000rem") are preserved during round-tripping instead of being lost.

Key changes:
- Introduced `AttCache` class in `libmei/addons/att.h`, inheriting from `Att`, using a `std::map<std::string, std::string>` for storage.
- Added `HasCacheValue`, `GetCacheValue`, and `SetCacheValue` virtual methods to the `Att` base class.
- Updated the libMEI Python generator (`libmei/tools/cpp.py`) to handle `AttCache` inheritance and generate `Read`/`Write` methods that utilize the cache.
- Enabled caching for `width` and `height` attributes in the `shared` module.
- Regenerated all `libmei/dist/` attribute classes.

---
*PR created automatically by Jules for task [4147495027441583146](https://jules.google.com/task/4147495027441583146) started by @rettinghaus*